### PR TITLE
Fix building when __tests__ directory present

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npx jest",
     "build": "npm run build:common && npm run build:types",
     "build:types": "tsc --emitDeclarationOnly",
-    "build:common": "rm -rf dist && node esbuild.js && npm run build:types"
+    "build:common": "rm -rf dist && node esbuild.js"
   },
   "keywords": [
     "i18next",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,5 +105,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
Mere presence of `__tests__` directory was breaking our build (`__tests__` and `src` directories being present in `dist` directory). This small change fixes it and now just needed files are generated in the top level of `dist`